### PR TITLE
Modify get_biosamples_for_study to retrieve only biosample IDs

### DIFF
--- a/src/nmdc_mcp/tools.py
+++ b/src/nmdc_mcp/tools.py
@@ -827,7 +827,7 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
 
         projection = ["id"]
 
-        biosamples = fetch_nmdc_biosample_records_paged(
+        biosample_ids = fetch_nmdc_biosample_records_paged(
             filter_criteria=filter_criteria,
             projection=projection,
             max_records=max_records,
@@ -835,23 +835,25 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
         )
 
         # Check if results may have been truncated
-        note = f"Found {len(biosamples)} biosample IDs associated with study {study_id}"
-        potentially_truncated = len(biosamples) == max_records
+        note = (
+            f"Found {len(biosample_ids)} biosample IDs associated with study {study_id}"
+        )
+        potentially_truncated = len(biosample_ids) == max_records
         if potentially_truncated:
             note += (
                 f" (limited to max_records={max_records}; there may be more results)"
             )
             logging.warning(
                 f"Potential truncation in get_biosamples_for_study: "
-                f"returned {len(biosamples)} IDs for study {study_id}, "
+                f"returned {len(biosample_ids)} IDs for study {study_id}, "
                 f"may be more results beyond max_records={max_records}"
             )
 
         return {
             "study_id": study_id,
             "study_name": study_data.get("name", ""),
-            "biosample_ids": biosamples,
-            "biosample_count": len(biosamples),
+            "biosample_ids": biosample_ids,
+            "biosample_count": len(biosample_ids),
             "max_records": max_records,
             "potentially_truncated": potentially_truncated,
             "note": note,

--- a/src/nmdc_mcp/tools.py
+++ b/src/nmdc_mcp/tools.py
@@ -765,14 +765,14 @@ def get_study_for_biosample(biosample_id: str) -> dict[str, Any]:
 
 def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, Any]:
     """
-    Get biosamples associated with a specific study.
+    Get biosample IDs associated with a specific study.
 
     Args:
         study_id (str): NMDC study ID (e.g., "nmdc:sty-11-xyz789")
-        max_records (int): Maximum number of biosamples to return
+        max_records (int): Maximum number of biosample IDs to return
 
     Returns:
-        Dict[str, Any]: Dictionary containing the biosamples and metadata
+        Dict[str, Any]: Dictionary containing the biosample IDs and metadata
 
     Examples:
         - get_biosamples_for_study("nmdc:sty-11-xyz789")
@@ -797,17 +797,7 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
         # Search for biosamples that have this study in their associated_studies field
         filter_criteria = {"associated_studies": study_id}
 
-        projection = [
-            "id",
-            "name",
-            "collection_date",
-            "ecosystem",
-            "ecosystem_category",
-            "ecosystem_type",
-            "ecosystem_subtype",
-            "geo_loc_name",
-            "associated_studies",
-        ]
+        projection = ["id"]
 
         biosamples = fetch_nmdc_biosample_records_paged(
             filter_criteria=filter_criteria,
@@ -816,18 +806,19 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
             verbose=True,
         )
 
-        # Format the collection_date field to make it more readable
-        for biosample in biosamples:
-            clean_collection_date(biosample)
+        # Check if results may have been truncated
+        note = f"Found {len(biosamples)} biosample IDs associated with study {study_id}"
+        if len(biosamples) == max_records:
+            note += f" (limited to max_records={max_records}; there may be more results)"
 
         return {
             "study_id": study_id,
             "study_name": study_data.get("name", ""),
             "biosamples": biosamples,
             "biosample_count": len(biosamples),
-            "note": (
-                f"Found {len(biosamples)} biosamples associated with study {study_id}"
-            ),
+            "max_records": max_records,
+            "potentially_truncated": len(biosamples) == max_records,
+            "note": note,
         }
 
     except Exception as e:

--- a/src/nmdc_mcp/tools.py
+++ b/src/nmdc_mcp/tools.py
@@ -867,7 +867,7 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
             "biosample_count": 0,
             "max_records": max_records,
             "potentially_truncated": False,
-            "error": f"Failed to get biosamples for study {study_id}: {str(e)}",
+            "error": f"Failed to get biosample IDs for study {study_id}: {str(e)}",
             "note": (
                 f"Error occurred while retrieving biosample IDs "
                 f"for study {study_id}"

--- a/src/nmdc_mcp/tools.py
+++ b/src/nmdc_mcp/tools.py
@@ -786,12 +786,15 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
     Examples:
         - get_biosamples_for_study("nmdc:sty-11-xyz789")
         - get_biosamples_for_study("nmdc:sty-11-xyz789", max_records=100)
-        
+
         Example return:
         {
             "study_id": "nmdc:sty-11-xyz789",
             "study_name": "Example Study",
-            "biosample_ids": [{"id": "nmdc:bsm-11-abc123"}, {"id": "nmdc:bsm-11-def456"}],
+            "biosample_ids": [
+                {"id": "nmdc:bsm-11-abc123"},
+                {"id": "nmdc:bsm-11-def456"}
+            ],
             "biosample_count": 2,
             "max_records": 50,
             "potentially_truncated": False,
@@ -835,7 +838,9 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
         note = f"Found {len(biosamples)} biosample IDs associated with study {study_id}"
         potentially_truncated = len(biosamples) == max_records
         if potentially_truncated:
-            note += f" (limited to max_records={max_records}; there may be more results)"
+            note += (
+                f" (limited to max_records={max_records}; there may be more results)"
+            )
             logging.warning(
                 f"Potential truncation in get_biosamples_for_study: "
                 f"returned {len(biosamples)} IDs for study {study_id}, "
@@ -861,7 +866,10 @@ def get_biosamples_for_study(study_id: str, max_records: int = 50) -> dict[str, 
             "max_records": max_records,
             "potentially_truncated": False,
             "error": f"Failed to get biosamples for study {study_id}: {str(e)}",
-            "note": f"Error occurred while retrieving biosample IDs for study {study_id}",
+            "note": (
+                f"Error occurred while retrieving biosample IDs "
+                f"for study {study_id}"
+            ),
         }
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -670,7 +670,7 @@ class TestNMDCTools(unittest.TestCase):
         # Verify result structure
         self.assertEqual(result["study_id"], "nmdc:sty-11-xyz789")
         self.assertEqual(result["study_name"], "Test Study")
-        self.assertEqual(result["biosamples"], mock_biosamples)
+        self.assertEqual(result["biosample_ids"], mock_biosamples)
         self.assertEqual(result["biosample_count"], 2)
         self.assertEqual(result["max_records"], 50)
         self.assertEqual(result["potentially_truncated"], False)
@@ -686,7 +686,11 @@ class TestNMDCTools(unittest.TestCase):
 
         # Verify error handling
         self.assertEqual(result["study_id"], "nmdc:sty-11-missing")
-        self.assertEqual(result["biosamples"], [])
+        self.assertEqual(result["study_name"], "")
+        self.assertEqual(result["biosample_ids"], [])
+        self.assertEqual(result["biosample_count"], 0)
+        self.assertEqual(result["max_records"], 50)
+        self.assertEqual(result["potentially_truncated"], False)
         self.assertIn("error", result)
         self.assertIn("Study nmdc:sty-11-missing not found", result["error"])
 
@@ -700,7 +704,11 @@ class TestNMDCTools(unittest.TestCase):
 
         # Verify exception handling
         self.assertEqual(result["study_id"], "nmdc:sty-11-xyz789")
-        self.assertEqual(result["biosamples"], [])
+        self.assertEqual(result["study_name"], "")
+        self.assertEqual(result["biosample_ids"], [])
+        self.assertEqual(result["biosample_count"], 0)
+        self.assertEqual(result["max_records"], 50)
+        self.assertEqual(result["potentially_truncated"], False)
         self.assertIn("error", result)
         self.assertIn("Failed to get biosamples for study", result["error"])
         self.assertIn("Database connection error", result["error"])
@@ -725,6 +733,7 @@ class TestNMDCTools(unittest.TestCase):
 
         # Verify result structure includes truncation warning
         self.assertEqual(result["study_id"], "nmdc:sty-11-xyz789")
+        self.assertEqual(result["study_name"], "Test Study")
         self.assertEqual(result["biosample_count"], 10)
         self.assertEqual(result["max_records"], 10)
         self.assertEqual(result["potentially_truncated"], True)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -710,7 +710,7 @@ class TestNMDCTools(unittest.TestCase):
         self.assertEqual(result["max_records"], 50)
         self.assertEqual(result["potentially_truncated"], False)
         self.assertIn("error", result)
-        self.assertIn("Failed to get biosamples for study", result["error"])
+        self.assertIn("Failed to get biosample IDs for study", result["error"])
         self.assertIn("Database connection error", result["error"])
 
     @patch("nmdc_mcp.tools.fetch_nmdc_biosample_records_paged")


### PR DESCRIPTION
- Changed projection to only return 'id' field instead of full biosample data
- Updated docstring to reflect that function returns biosample IDs
- Added truncation detection and warning when max_records limit is reached
- Removed collection_date cleaning since that field is no longer retrieved
- Added potentially_truncated flag and max_records in response for transparency

🤖 Generated with [Claude Code](https://claude.ai/code)